### PR TITLE
Fix: page breaks.

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -3,7 +3,7 @@ name: Publish site to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - fix-baseurl-error
 
 jobs:
 

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -22,7 +22,9 @@ jobs:
         run: npm install
           
       - name: Build static page
-        run: npm run build
+        run: |
+          npm run build
+          touch ./out/.nojekyll
           
       - name: Deploy to GitHub Pages
         if: success()

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -3,7 +3,7 @@ name: Publish site to GitHub Pages
 on:
   push:
     branches:
-      - fix-baseurl-error
+      - main
 
 jobs:
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,6 +13,7 @@ export default function Home() {
     <Head>
       <title>Home Page - Kreee</title>
 
+      <meta name="siteBaseUrl" content="https://www.ohmykreee.top" />
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta name="author" content="Kreee" />


### PR DESCRIPTION
Reference: [Bypassing Jekyll on GitHub Pages - GitHub Blog](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/)

Jekyll does not copy files or directories that start with underscores to the final site, causing accessing  `_next`  folder failed and page breaking.